### PR TITLE
fix: Increase Server Action body size limit to 10MB for image uploads (#35)

### DIFF
--- a/__tests__/config/next.config.test.ts
+++ b/__tests__/config/next.config.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import nextConfig from '../../next.config';
+
+describe('Next.js Configuration', () => {
+    describe('Server Actions', () => {
+        it('should have serverActions bodySizeLimit configured', () => {
+            expect(nextConfig.experimental?.serverActions).toBeDefined();
+            expect(
+                nextConfig.experimental?.serverActions?.bodySizeLimit
+            ).toBeDefined();
+        });
+
+        it('should set bodySizeLimit to 10mb', () => {
+            expect(nextConfig.experimental?.serverActions?.bodySizeLimit).toBe(
+                '10mb'
+            );
+        });
+    });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -24,16 +24,35 @@ const nextConfig: NextConfig = {
     },
 
     /**
-     * Bundle Optimization (Phase B)
+     * Server Actions Configuration
      *
-     * Optimize package imports to reduce bundle size:
-     * - Stripe: Lazy-loaded on checkout routes only (Phase 3)
-     * - Cart Context: Lazy-loaded on cart/shoppe routes only
-     * - Supabase Client: Only included where needed
+     * Body Size Limit: Increased to 10MB to support large image uploads.
      *
-     * See docs: https://nextjs.org/docs/app/api-reference/next-config-js/optimizePackageImports
+     * Why 10MB?
+     * - Application validates up to 10MB in upload.ts (MAX_FILE_SIZE)
+     * - Client-side validation enforces 10MB in ImageUploader.tsx
+     * - Tests verify 10MB limit enforcement
+     * - Supports high-quality artwork images for gallery/shop
+     *
+     * Default is 1MB, which is too restrictive for this use case.
+     *
+     * See: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit
+     * Related: GitHub Issue #35
      */
     experimental: {
+        serverActions: {
+            bodySizeLimit: '10mb',
+        },
+        /**
+         * Bundle Optimization (Phase B)
+         *
+         * Optimize package imports to reduce bundle size:
+         * - Stripe: Lazy-loaded on checkout routes only (Phase 3)
+         * - Cart Context: Lazy-loaded on cart/shoppe routes only
+         * - Supabase Client: Only included where needed
+         *
+         * See docs: https://nextjs.org/docs/app/api-reference/next-config-js/optimizePackageImports
+         */
         optimizePackageImports: [
             '@stripe/react-stripe-js',
             '@stripe/stripe-js',


### PR DESCRIPTION
## Summary

Fixes #35

Increases Next.js Server Action body size limit from 1MB (default) to 10MB to support large image uploads in the admin interface.

## Changes

- Added `experimental.serverActions.bodySizeLimit: '10mb'` to `next.config.ts`
- Added test to verify configuration is set correctly

## Why 10MB?

- Application already validates up to 10MB in `upload.ts` (MAX_FILE_SIZE constant)
- Client validates 10MB in `ImageUploader.tsx` (DEFAULT_MAX_SIZE_MB constant)
- Existing tests verify 10MB limit enforcement
- Supports high-quality artwork images for gallery/shop

## Testing

- ✅ New test verifies configuration is set to '10mb'
- ✅ All existing tests pass
- ✅ Build succeeds

## Security Considerations

- Limit increased from 1MB to 10MB (reasonable for image uploads)
- Admin-only feature (protected by proxy.ts authentication)
- Session-based authentication required
- Vercel hosting handles this payload size without issue

## Documentation

- Added inline comments explaining the configuration
- Linked to Next.js official documentation
- Referenced GitHub issue #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)