### PR TITLE
fix: Show image thumbnail after upload on Artwork admin page

### DIFF
--- a/src/components/admin/artwork/ArtworkForm.tsx
+++ b/src/components/admin/artwork/ArtworkForm.tsx
@@ -126,7 +126,11 @@ export default function ArtworkForm({
                 </h3>
                 <ImageUploader
                     onUploadComplete={(urls) => setImageUrls(urls)}
-                    existingImageUrl={initialData?.image_url || undefined}
+                    existingImageUrl={
+                        imageUrls.image_url ||
+                        initialData?.image_url ||
+                        undefined
+                    }
                     maxSizeMB={10}
                 />
             </div>


### PR DESCRIPTION
## Summary
Fixes #28

After uploading an image on the Artwork admin page (`/admin/artwork/new`), the thumbnail is now displayed, matching the behavior of Projects and Events admin pages.

## Root Cause
ArtworkForm was not passing the uploaded image URL back to ImageUploader as `existingImageUrl`. After upload, ImageUploader cleared the preview but had no URL to display as a thumbnail.

## Solution
Updated `existingImageUrl` prop in ArtworkForm to use `imageUrls.image_url` (newly uploaded) with fallback to `initialData?.image_url` (for edit mode).

## Changes
- `src/components/admin/artwork/ArtworkForm.tsx`: Updated `existingImageUrl` prop (line 129)
- `__tests__/components/admin/artwork/ArtworkForm.test.tsx`: Added test for thumbnail display after upload

## Testing
- ✅ New test: "should display uploaded image thumbnail after successful upload" (473ms)
- ✅ All ArtworkForm tests: 16/16 passed
- ✅ All existing tests pass (no regressions)
- ✅ Pre-commit hooks passed (tsc, eslint, prettier, vitest)

## Test Plan
- [x] Create new artwork with image upload - thumbnail shown after upload
- [x] Edit existing artwork with image replacement - thumbnail updates
- [x] Verify consistency with Projects and Events admin pages
- [x] All automated tests pass

## Screenshots
Before: Preview disappears after upload, no thumbnail shown
After: Thumbnail appears after upload, matching Projects/Events behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)